### PR TITLE
Added a README.Rmd to compile to README.md, and a .Rproj file

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@
 ^\.travis.yml$
 ^\.travis\.yml$
 ^cran-comments.md$
+^README\.Rmd$
+^README-.*\.png$

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf
+.Rproj.user

--- a/README.Rmd
+++ b/README.Rmd
@@ -6,15 +6,20 @@ output:
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-
+```{r, echo = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "README-"
+)
+```
 
 [![Travis-CI Build Status](https://travis-ci.org/nutterb/pixiedust.svg?branch=master)](https://travis-ci.org/nutterb/pixiedust)
 
 # pixiedust
 After tidying up your analyses with the `broom` package, go ahead and grab the `pixiedust`.  Customize your table output and write it to markdown, HTML, LaTeX, or even just the console.  `pixiedust` makes it easy to customize the appearance of your tables in all of these formats by adding any number of "sprinkles", much in the same way you can add layers to a `ggplot`.
 
-
-```r
+```{r}
 fit <- lm(mpg ~ qsec + factor(am) + wt + factor(gear), data = mtcars)
 library(pixiedust)
 dust(fit) + 
@@ -25,13 +30,6 @@ dust(fit) +
                      std.error = "SE",
                      statistic = "T-statistic", 
                      p.value = "P-value")
-#>            Term Estimate    SE T-statistic P-value
-#> 1   (Intercept)    9.365 8.373       1.118    0.27
-#> 2          qsec    1.245 0.383       3.252   0.003
-#> 3   factor(am)1    3.151 1.941       1.624    0.12
-#> 4            wt   -3.926 0.743      -5.286 < 0.001
-#> 5 factor(gear)4   -0.268 1.655      -0.162    0.87
-#> 6 factor(gear)5    -0.27 2.063      -0.131     0.9
 ```
 
 ### Customizing with Sprinkles
@@ -71,95 +69,40 @@ Tables can be customized by row, column, or even by a single cell by adding spri
 
 To demonstrate, let's look at a simple linear model.  We build the model and generate the standard summary.  
 
-
-```r
+```{r}
 fit <- lm(mpg ~ qsec + factor(am) + wt + factor(gear), data = mtcars)
 
 summary(fit)
-#> 
-#> Call:
-#> lm(formula = mpg ~ qsec + factor(am) + wt + factor(gear), data = mtcars)
-#> 
-#> Residuals:
-#>     Min      1Q  Median      3Q     Max 
-#> -3.5064 -1.5220 -0.7517  1.3841  4.6345 
-#> 
-#> Coefficients:
-#>               Estimate Std. Error t value Pr(>|t|)    
-#> (Intercept)     9.3650     8.3730   1.118  0.27359    
-#> qsec            1.2449     0.3828   3.252  0.00317 ** 
-#> factor(am)1     3.1505     1.9405   1.624  0.11654    
-#> wt             -3.9263     0.7428  -5.286 1.58e-05 ***
-#> factor(gear)4  -0.2682     1.6555  -0.162  0.87257    
-#> factor(gear)5  -0.2697     2.0632  -0.131  0.89698    
-#> ---
-#> Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
-#> 
-#> Residual standard error: 2.55 on 26 degrees of freedom
-#> Multiple R-squared:  0.8498,	Adjusted R-squared:  0.8209 
-#> F-statistic: 29.43 on 5 and 26 DF,  p-value: 6.379e-10
 ```
 
 While the summary is informative and useful, it is full of "stats-speak" and isn't necessarily in a format that is suitable for publication or submission to a client.  The `broom` package provides the summary in tidy format that, serendipitously, it a lot closer to what we would want for formal reports.
 
-
-```r
+```{r}
 library(broom)
 tidy(fit)
-#>            term   estimate std.error  statistic      p.value
-#> 1   (Intercept)  9.3650443 8.3730161  1.1184792 2.735903e-01
-#> 2          qsec  1.2449212 0.3828479  3.2517387 3.168128e-03
-#> 3   factor(am)1  3.1505178 1.9405171  1.6235455 1.165367e-01
-#> 4            wt -3.9263022 0.7427562 -5.2861251 1.581735e-05
-#> 5 factor(gear)4 -0.2681630 1.6554617 -0.1619868 8.725685e-01
-#> 6 factor(gear)5 -0.2697468 2.0631829 -0.1307430 8.969850e-01
 ```
 
 It has been observed by some, however, that even this summary isn't quite ready for publication.  There are too many decimal places, the p-value employ scientific notation, and column titles like "statistic" don't specify what type of statistic.  These kinds of details aren't the purview of `broom`, however, as `broom` is focused on tidying the results of a model for further analysis (particularly with respect to comparing slightly varying models).
 
 The `pixiedust` package diverts from `broom`'s mission here and provides the ability to customize the `broom` output for presentation.  The initial `dust` object returns a table that is largely similar to the `broom` output.  Truthfully, it may be less desirable because it has converted all of those numerical values into character strings.  This has the consequence of losing the numerical formatting employed by printing a data frame.
 
-
-```r
+```{r}
 library(pixiedust)
 dust(fit)
-#>            term           estimate         std.error          statistic
-#> 1   (Intercept)   9.36504430865836  8.37301612033658   1.11847919245161
-#> 2          qsec   1.24492121340088 0.382847869162145    3.2517386504602
-#> 3   factor(am)1   3.15051775932893  1.94051711270669   1.62354546563854
-#> 4            wt   -3.9263021501002 0.742756198609962   -5.2861250534807
-#> 5 factor(gear)4 -0.268163000929796  1.65546166120695 -0.161986838604456
-#> 6 factor(gear)5 -0.269746805223248   2.0631829212229 -0.130743039043461
-#>                p.value
-#> 1    0.273590282784449
-#> 2  0.00316812765022556
-#> 3    0.116536745986852
-#> 4 1.58173505907644e-05
-#> 5    0.872568516561885
-#> 6    0.896984955536724
 ```
 
 Where `pixiedust` shows its strength is the ease of which these tables can be customized.  The code below rounds the columns `estimate`, `std.error`, and `statistic` to three decimal places each, and then formats the `p.value` into a format that happens to be one that I like.
 
-
-```r
+```{r}
 x <- dust(fit) + 
   sprinkle(col = 2:4, round = 3) + 
   sprinkle(col = 5, fn = quote(pvalString(value)))
 x
-#>            term estimate std.error statistic p.value
-#> 1   (Intercept)    9.365     8.373     1.118    0.27
-#> 2          qsec    1.245     0.383     3.252   0.003
-#> 3   factor(am)1    3.151     1.941     1.624    0.12
-#> 4            wt   -3.926     0.743    -5.286 < 0.001
-#> 5 factor(gear)4   -0.268     1.655    -0.162    0.87
-#> 6 factor(gear)5    -0.27     2.063    -0.131     0.9
 ```
 
 Now we're almost there!  Let's change up the column names, and while we're add it, let's add some "bold" markers to the statistically significant terms in order to make them stand out some (I say "bold" because the console output doesn't show up in bold, but with the markdown tags for bold text.  In a rendered table, the text would actually be rendered in bold).
 
-
-```r
+```{r}
 x <- x + 
   sprinkle(col = c("estimate", "p.value"), 
            row = c(2, 4), 
@@ -171,13 +114,6 @@ x <- x +
                 p.value = "P-value")
 
 x
-#>            Term   Estimate    SE T-statistic     P-value
-#> 1   (Intercept)    9.365   8.373       1.118      0.27  
-#> 2          qsec  **1.245** 0.383       3.252   **0.003**
-#> 3   factor(am)1    3.151   1.941       1.624      0.12  
-#> 4            wt **-3.926** 0.743      -5.286 **< 0.001**
-#> 5 factor(gear)4   -0.268   1.655      -0.162      0.87  
-#> 6 factor(gear)5    -0.27   2.063      -0.131       0.9
 ```
 
 ### Upcoming Developments

--- a/pixiedust.Rproj
+++ b/pixiedust.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
I've suggested adding a README.Rmd file, which compiles to README.md with `knit("README.Rmd")`. (See `?devtools::use_readme_rmd`). This has two advantages:

1. Code is compiled without `>`, which makes it a bit easier to copy/paste into a terminal.
2. This keeps the README up to date with the package usage and output (for example, in this process I found the README uses `dust_colnames`, which appears to have been renamed `sprinkle_colnames` in the released version).

I also added a .Rproj file just so that developers can immediately clone and open the project, but it's up to you whether to use it.

Thanks for your awesome work on this package.