### PR TITLE
Fix invalid LaTeX width/height with dplyr >0.5.0

### DIFF
--- a/R/print_dust_latex.R
+++ b/R/print_dust_latex.R
@@ -388,7 +388,7 @@ numeric_longtable_newline <- function(n, redefine = FALSE){
 
 needs_parbox <- function(x)
 {
-  !is.na(x$width) | 
+  is.finite(x$width) | 
     (x$halign != x$default_halign) | 
     x$valign != "" | 
     x$merge
@@ -462,7 +462,8 @@ determine_column_width <- function(Joint, x)
     dplyr::select(row, col, width) %>%
     dplyr::group_by(col) %>%
     dplyr::summarise(width = max(width, na.rm=TRUE)) %>%
-    dplyr::ungroup() 
+    dplyr::ungroup() %>%
+    dplyr::mutate(width = ifelse(is.finite(width), width, NA))
 }
 
 determine_row_height <- function(part)
@@ -479,7 +480,7 @@ determine_row_height <- function(part)
     dplyr::group_by(row) %>%
     dplyr::summarise(height = max(height, na.rm=TRUE)) %>%
     dplyr::ungroup() %>%
-    dplyr::mutate(height = ifelse(is.na(height),
+    dplyr::mutate(height = ifelse(!is.finite(height),
                          "", paste0("\\\\[", height, "pt]"))) %>%
     '$'("height") 
 }

--- a/tests/testthat/test-print_dust_methods.R
+++ b/tests/testthat/test-print_dust_methods.R
@@ -175,6 +175,15 @@ test_that(
 )
 
 test_that(
+  "print_dust_latex does not output invalid -Inf width or height", 
+  {
+    fit <- lm(mpg ~ qsec + factor(am) + wt + factor(gear), data = mtcars)
+    x <- print_dust_latex(dust(fit))
+    expect_false(grepl("-Inf", x))
+  }
+)
+
+test_that(
   "html tables with bookdown label",
   {
     fit <- lm(mpg ~ qsec + factor(am) + wt + factor(gear), data = mtcars)


### PR DESCRIPTION
* Addresses issue #82

* Change `determine_column_width()` and `determine_row_height()` to
handle `-Inf`. `determine_column_width()` now turns `-Inf` into `NA`.
`determine_row_height()` now turns `-Inf` into empty string. With these
changes, the functions now give the same output with dplyr 0.5.0 and
versions after 0.5.0.

    * These changes are needed because dplyr versions after 0.5.0 output
`-Inf` in place of `NA` when using `max(x, na.rm = TRUE)` if all
elements of `x` are `NA`. pixiedust uses dplyr's `max()` to determine
row widths and column heights for LaTeX, and the `-Inf` values lead to
invalid LaTeX, e.g. `parbox[]{-Infpt}`.

* Change `needs_parbox()` to consider only finite widths, instead of
non-`NA` widths. Non-`NA` widths could include `Inf` and `-Inf`.