### PR TITLE
Do not match on complete error message of checkmate in tests

### DIFF
--- a/tests/testthat/test-sprinkle_fixed_header.R
+++ b/tests/testthat/test-sprinkle_fixed_header.R
@@ -84,7 +84,7 @@ test_that(
   "Cast an error if x does not inherit class dust",
   {
     expect_error(sprinkle_fixed_header(mtcars),
-                 "Must have class 'dust'")
+                 "class 'dust'")
   }
 )
 


### PR DESCRIPTION
Hi there,

While preparing a new release of checkmate, I improved some error messages to provide additional information, e.g. the location of the first missing value in a vector. This unfortunately broke a unit test in your package. This PR should fix the test in question. Instead of matching on the complete sentence, the new pattern just matches the relevant part.
I currently see no better way around this to make this more future-proof ...

It would be great if you could release a new version to CRAN in the next few weeks.

Best,
Michel